### PR TITLE
Early return to handle the `plotly_selected` events fired by `plot_api` calls

### DIFF
--- a/script.js
+++ b/script.js
@@ -110,6 +110,7 @@ Papa.parse("data.csv", {
 
     //set up selection listeners
     function hist_im_select(e) {
+      if(e && !e.range) return;
       im_range = e ? [e.range.x[0], e.range.x[1]] : [-Infinity, Infinity];
       im.filter(im_range);
       react();
@@ -120,6 +121,7 @@ Papa.parse("data.csv", {
     hist_im.on('plotly_selecting',   hist_im_select);
 
     function hist_gdp_select(e) {
+      if(e && !e.range) return;
       gdp_range = e ? [e.range.x[0], e.range.x[1]] : [-Infinity, Infinity];
       gdp.filter(gdp_range);
       react();


### PR DESCRIPTION
Please note that the `plotly_selected` emitted after a plot_api call (as provided by [v2.13.3](https://github.com/plotly/plotly.js/releases/tag/v2.13.3) has no `range` and `lassoPoints` while there is no active selection kept in the graph.

cc: @nicolaskruchten @alexcjohnson 